### PR TITLE
Bump deasync version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/ujc/get-port-sync#readme",
   "dependencies": {
-    "deasync": "^0.1.8",
+    "deasync": "^0.1.27",
     "get-port": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump deasync version to latest (which includes prebuilt binaries for the latest node LTS release (16x))

-----------

This change won't affect anything in this module, but will make it easier to use this module in a dockerized environment where the required build utils needed to build de-async from scratch are not available).